### PR TITLE
Update fct_full_factorial.R

### DIFF
--- a/R/fct_full_factorial.R
+++ b/R/fct_full_factorial.R
@@ -23,9 +23,8 @@
 #'
 #' @importFrom stats runif na.omit
 #'
-#' @return A list with information on the design parameters.
-#' @return Data frame with the full factorial field book.
-#'
+#' @return A list with information two elements: \code{infoDesign} is a 
+#' and \code{fieldBook} is a data frame with the full factorial field book.
 #'
 #' @references
 #' Federer, W. T. (1955). Experimental Design. Theory and Application. New York, USA. The


### PR DESCRIPTION
- updating docs to indicate that only one object is returned from function
- this is a pretty minor change but for the document to be clear, similar updates should be applied to other functions. e.g. RCBD: https://github.com/DidierMurilloF/FielDHub/blob/1331d17ac27efba06c8fecdba288c832dd8b221f/R/fct_RCBD.R#L18
- see, e.g. https://stackoverflow.com/a/35095188/199217 
- and https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Documenting-functions "If a list with multiple values is returned, you can use entries of the form `\item{comp_i}{Description of comp_i.}`"