### PR TITLE
fix: select non-prime field sizes in field_dimensions() and do_optim()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -16,6 +16,12 @@ knitr::opts_chunk$set(
 
 # Changelog
 
+# FielDHub (development version)
+
+### Fix bugs:
+
+* Fixed a bug in `diagonal_arrangement()` and `sparse_allocation()` where the internal non-prime field-size filter `t[-numbers::isPrime(t)]` used a logical vector as a negative index and returned wrong or no field dimensions; it now uses `t[!numbers::isPrime(t)]`.
+
 # FielDHub 1.3.1
 
 ### New Features in the Shiny App

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,15 @@
 
 # Changelog
 
+# FielDHub (development version)
+
+### Fix bugs:
+
+- Fixed a bug in `diagonal_arrangement()` and `sparse_allocation()` where the
+  internal non-prime field-size filter `t[-numbers::isPrime(t)]` used a logical
+  vector as a negative index and returned wrong or no field dimensions; it now
+  uses `t[!numbers::isPrime(t)]`.
+
 # FielDHub 1.3.1
 
 ### New Features in the Shiny App

--- a/R/fct_diagonal_arrangement.R
+++ b/R/fct_diagonal_arrangement.R
@@ -259,7 +259,6 @@ diagonal_arrangement <- function(
             t1 <- floor(lines + lines * 0.10)
             t2 <- ceiling(lines + lines * 0.20)
             t <- t1:t2
-            n <- t[-numbers::isPrime(t)]
             choices_list <- list()
             i <- 1
             for (n in t) {
@@ -883,7 +882,7 @@ field_dimensions <- function(lines_within_loc) {
     t1 <- floor(lines_within_loc + lines_within_loc * 0.10)
     t2 <- ceiling(lines_within_loc + lines_within_loc * 0.20)
     t <- t1:t2
-    non_primes <- t[-numbers::isPrime(t)]
+    non_primes <- t[!numbers::isPrime(t)]
     choices_list <- list()
     i <- 1
     for (n in non_primes) {

--- a/R/fct_do_optim.R
+++ b/R/fct_do_optim.R
@@ -370,7 +370,7 @@ sparse_allocation <- function(
         t1 <- floor(lines_within_loc + lines_within_loc * 0.11)
         t2 <- ceiling(lines_within_loc + lines_within_loc * 0.20)
         t <- t1:t2
-        non_primes <- t[-numbers::isPrime(t)]
+        non_primes <- t[!numbers::isPrime(t)]
         choices_list <- list()
         i <- 1
         for (n in non_primes) {

--- a/R/mod_Diagonal.R
+++ b/R/mod_Diagonal.R
@@ -382,7 +382,6 @@ mod_Diagonal_server <- function(id) {
       t1 <- floor(lines + lines * 0.11)
       t2 <- ceiling(lines + lines * 0.20)
       t <- t1:t2
-      n <- t[-numbers::isPrime(t)]
       withProgress(message = 'Getting field dimensions ...', {
         choices_list <- list()
         i <- 1

--- a/R/mod_diagonal_multiple.R
+++ b/R/mod_diagonal_multiple.R
@@ -509,7 +509,6 @@ mod_diagonal_multiple_server <- function(id) {
             t1 <- floor(lines + lines * 0.10)
             t2 <- ceiling(lines + lines * 0.20)
             t <- t1:t2
-            n <- t[-numbers::isPrime(t)]
             withProgress(message = 'Getting field dimensions ...', {
                 choices_list <- list()
                 i <- 1

--- a/tests/testthat/test_field_dimensions.R
+++ b/tests/testthat/test_field_dimensions.R
@@ -1,0 +1,14 @@
+library(FielDHub)
+
+test_that("field_dimensions() proposes non-prime field sizes for a prime-free range", {
+  # Regression test for the isPrime() negative-index bug.
+  # field_dimensions() selected the candidate field sizes with
+  #   non_primes <- t[-numbers::isPrime(t)]
+  # numbers::isPrime() returns a logical vector, so used as a negative index it
+  # only ever dropped the first element; for a prime-free size range it even
+  # collapsed to t[0] = integer(0). With lines = 105 the size range is
+  # t = 115:126 (no primes), so the buggy expression returned zero dimension
+  # candidates. The fix uses t[!numbers::isPrime(t)].
+  dims <- FielDHub:::field_dimensions(105)
+  expect_gt(length(unlist(dims)), 0)
+})


### PR DESCRIPTION
This PR is part of an AI-assisted bug hunt across the package source; see #62
for the overview.

## Problem
`field_dimensions()` and `sparse_allocation()` filter out prime field sizes with
`t[-numbers::isPrime(t)]`. `numbers::isPrime()` returns a *logical* vector, so this
negates a logical (`-TRUE` is -1, `-FALSE` is 0) and uses the result as an index,
dropping the wrong elements - and returning nothing when the first candidate is
non-prime. These helpers back the field-dimension choosers of the Diagonal and Sparse
Shiny modules, so the app can end up offering no / wrong dimension options.

## Before (master, v1.5.0)
```r
unname(unlist(FielDHub:::field_dimensions(105)))
#> NULL
```

## After (this PR)
```r
unname(unlist(FielDHub:::field_dimensions(105)))
#>  [1] "5 x 23"  "9 x 13"  "7 x 17"  "5 x 24"  "10 x 12" "6 x 20"  "12 x 10" "8 x 15"  "11 x 11"
#> [10] "5 x 25"  "7 x 18"  "9 x 14"  "6 x 21"
```

## Fix
Use logical subsetting `t[!numbers::isPrime(t)]` in `field_dimensions()`
(`fct_diagonal_arrangement.R`) and `sparse_allocation()` (`fct_do_optim.R`). The same
broken expression also appeared as a dead line - immediately overwritten by the
following `for (n in t)` loop - in `diagonal_arrangement()`, `mod_Diagonal()` and
`mod_diagonal_multiple()`; those dead lines are removed. Adds a regression test for
`field_dimensions()`.

Related to #62

> The before/after output above was captured locally (before on master v1.5.0, after on this branch).
