### PR TITLE
fix: base alpha_lattice() prime check on the treatment count

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -16,6 +16,12 @@ knitr::opts_chunk$set(
 
 # Changelog
 
+# FielDHub (development version)
+
+### Fix bugs:
+
+* Fixed a bug in `alpha_lattice()` where the prime-number check was applied to the raw treatment argument `t` instead of the number of treatments, so supplying treatments as a vector (e.g. `t = 1:8`) raised the error "the condition has length > 1"; it now checks `numbers::isPrime(nt)`.
+
 # FielDHub 1.3.1
 
 ### New Features in the Shiny App

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,16 @@
 
 # Changelog
 
+# FielDHub (development version)
+
+### Fix bugs:
+
+- Fixed a bug in `alpha_lattice()` where the prime-number check was
+  applied to the raw treatment argument `t` instead of the number of
+  treatments, so supplying treatments as a vector (e.g. `t = 1:8`)
+  raised the error "the condition has length > 1"; it now checks
+  `numbers::isPrime(nt)`.
+
 # FielDHub 1.3.1
 
 ### New Features in the Shiny App

--- a/R/fct_alpha_lattice.R
+++ b/R/fct_alpha_lattice.R
@@ -128,10 +128,8 @@ alpha_lattice <- function(t = NULL,
   if (k >= nt) shiny::validate('incomplete_blocks() requires that k < t.')
   if (!is.null(locationNames)) locationNames <- toupper(locationNames)
   if(is.null(locationNames) || length(locationNames) != l) locationNames <- 1:l
-  if (numbers::isPrime(t)) shiny::validate('Combinations for this amount of treatments do not exist.')
+  if (numbers::isPrime(nt)) shiny::validate('Combinations for this amount of treatments do not exist.')
   s <- nt / k
-  dt <- numbers::divisors(t)
-  dt <- dt[2:(length(dt) - 1)]
   if (s %% 1 != 0) shiny::validate('Combinations for this amount of treatments do not exist.')
   
   nunits <- k

--- a/tests/testthat/test_alpha_lattice.R
+++ b/tests/testthat/test_alpha_lattice.R
@@ -1,0 +1,18 @@
+library(FielDHub)
+
+test_that("alpha_lattice() accepts treatments supplied as a vector (issue #20)", {
+  # Regression test for the isPrime() "condition has length > 1" bug.
+  # alpha_lattice() guarded against a prime number of treatments with
+  #   if (numbers::isPrime(t)) ...
+  # but t is the raw treatment argument, which may be a vector (e.g. t = 1:8).
+  # numbers::isPrime() then returns a logical vector, so the if() condition had
+  # length > 1 and the call errored. A character vector errored at the same line
+  # too. The (dead) line dt <- numbers::divisors(t) had the same vector problem.
+  # The fix checks the treatment count, numbers::isPrime(nt), instead.
+  alpha_num <- alpha_lattice(t = 1:8, k = 2, r = 2, seed = 1)
+  expect_s3_class(alpha_num, "FielDHub")
+  expect_equal(nrow(alpha_num$fieldBook), 8 * 2)
+
+  alpha_chr <- alpha_lattice(t = LETTERS[1:8], k = 2, r = 2, seed = 1)
+  expect_s3_class(alpha_chr, "FielDHub")
+})


### PR DESCRIPTION
This PR is part of an AI-assisted bug hunt across the package source; see #62
for the overview.

## Problem
`alpha_lattice()` applies the prime-number check to the raw treatment argument `t`
instead of the number of treatments `nt`. When treatments are supplied as a vector,
`numbers::isPrime(t)` returns a vector and the `if` condition errors. This is the same
error reported in #20 (closed but never fixed).

## Before (master, v1.5.0)
```r
FielDHub::alpha_lattice(t = 1:8, k = 2, r = 2)
#> Error: the condition has length > 1
```

## After (this PR)
```r
al <- FielDHub::alpha_lattice(t = 1:8, k = 2, r = 2)
head(al$fieldBook, 4)
#>   ID LOCATION PLOT REP IBLOCK UNIT ENTRY TREATMENT
#> 1  1        1  101   1      1    1     5       G-5
#> 2  2        1  102   1      1    2     2       G-2
#> 3  3        1  103   1      2    1     6       G-6
#> 4  4        1  104   1      2    2     4       G-4
```

## Fix
Check `numbers::isPrime(nt)` instead of `isPrime(t)`, so a vector of treatments is
accepted. Also removes two dead lines (`dt <- numbers::divisors(t); dt <- dt[...]`)
whose result is never used and which would themselves fail on a vector `t`. Adds a
regression test.

Related to #20, #62

> The before/after output above was captured locally (before on master v1.5.0, after on this branch).
