### PR TITLE
fix: guard swap_pairs() against an empty distance range on small fields

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -16,6 +16,12 @@ knitr::opts_chunk$set(
 
 # Changelog
 
+# FielDHub (development version)
+
+### Fix bugs:
+
+* Fixed a bug in `swap_pairs()` where on small fields the starting distance could exceed the field diagonal, so the internal threshold sequence `seq(starting_dist, minDist, 1)` errored with "wrong sign in 'by' argument"; the distance range is now guarded and the input design is returned unchanged when no swap distance is feasible.
+
 # FielDHub 1.3.1
 
 ### New Features in the Shiny App

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,16 @@
 
 # Changelog
 
+# FielDHub (development version)
+
+### Fix bugs:
+
+- Fixed a bug in `swap_pairs()` where on small fields the starting
+  distance could exceed the field diagonal, so the internal threshold
+  sequence `seq(starting_dist, minDist, 1)` errored with "wrong sign in
+  'by' argument"; the distance range is now guarded and the input design
+  is returned unchanged when no swap distance is feasible.
+
 # FielDHub 1.3.1
 
 ### New Features in the Shiny App

--- a/R/utils_swap_functions.R
+++ b/R/utils_swap_functions.R
@@ -207,10 +207,15 @@ swap_pairs <- function(X,
   genos <- unique(init_pd$geno)
   w <- 2L
 
+  # Guard against a reversed/empty threshold range: on very small fields the
+  # field diagonal (minDist) can be shorter than starting_dist, which would make
+  # seq(starting_dist, minDist, 1) error with "wrong sign in 'by' argument".
+  dist_seq <- if (minDist >= starting_dist) seq(starting_dist, minDist, 1) else numeric(0)
+
   # ------------------------------------------------------------------ #
   #  Main loop over increasing minimum-distance thresholds              #
   # ------------------------------------------------------------------ #
-  for (min_dist in seq(starting_dist, minDist, 1)) {
+  for (min_dist in dist_seq) {
     n_iter <- 1L
 
     while (n_iter <= stop_iter) {

--- a/tests/testthat/test_swap_pairs.R
+++ b/tests/testthat/test_swap_pairs.R
@@ -1,0 +1,16 @@
+library(FielDHub)
+
+test_that("swap_pairs() handles fields smaller than the starting distance", {
+  # Regression test for the empty/reversed distance-range bug.
+  # swap_pairs() looped with
+  #   for (min_dist in seq(starting_dist, minDist, 1))
+  # where minDist = sqrt(nr^2 + nc^2) is the field diagonal and starting_dist
+  # defaults to 3. On a small field (here 2 x 2, diagonal ~2.83 < 3) the call
+  # seq(3, 2.83, 1) errored with "wrong sign in 'by' argument". The fix guards
+  # the range and returns the input design unchanged when no swap distance is
+  # feasible.
+  set.seed(1)
+  X <- matrix(sample(c(1, 1, 2, 2)), nrow = 2, ncol = 2)
+  res <- swap_pairs(X)
+  expect_identical(res$optim_design, X)
+})


### PR DESCRIPTION
This PR is part of an AI-assisted bug hunt across the package source; see #62
for the overview.

## Problem
`swap_pairs()` loops over `seq(starting_dist, minDist, 1)`. On very small fields the
field diagonal (`minDist`) can be smaller than `starting_dist`, so the sequence runs
"downhill" and `seq(..., by = 1)` errors with "wrong sign in 'by' argument".

## Before (master, v1.5.0)
```r
# a 2 x 2 field with one twice-replicated genotype: swap_pairs() starts at
# starting_dist = 3, but the field diagonal is only sqrt(8) ~= 2.83
FielDHub::partially_replicated(nrows = 2, ncols = 2, repGens = c(2, 1), repUnits = c(1, 2), seed = 1)
#> Error: wrong sign in 'by' argument
```

## After (this PR)
```r
pr <- FielDHub::partially_replicated(nrows = 2, ncols = 2, repGens = c(2, 1), repUnits = c(1, 2), seed = 1)
head(pr$fieldBook, 4)
#> # A tibble: 4 × 11
#>      ID EXPT  LOCATION YEAR   PLOT   ROW COLUMN   REP CHECKS ENTRY TREATMENT
#>   <int> <chr> <chr>    <chr> <dbl> <int>  <int> <int>  <dbl> <dbl> <chr>
#> 1     1 Expt1 LOC1     2026    101     1      1     1      3     3 G3
#> 2     2 Expt1 LOC1     2026    102     1      2     2      3     3 G3
#> 3     3 Expt1 LOC1     2026    103     2      2     1      0     2 G2
#> 4     4 Expt1 LOC1     2026    104     2      1     1      0     1 G1
```

## Fix
Build the threshold sequence only when `minDist >= starting_dist`; otherwise use an
empty range so the loop is skipped and the input design is returned unchanged (no swap
is feasible on such a small field). Adds a regression test.

Related to #62

> The before/after output above was captured locally (before on master v1.5.0, after on this branch).
