### PR TITLE
fix: build gen.list outside the column-count guard in split_families()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -16,6 +16,12 @@ knitr::opts_chunk$set(
 
 # Changelog
 
+# FielDHub (development version)
+
+### Fix bugs:
+
+* Fixed a bug in `split_families()` where the `gen.list` assignment sat after `stop()` inside the column-count check, so valid three-column input never created `gen.list` and the function errored with "object 'gen.list' not found"; the assignment now runs after the guard.
+
 # FielDHub 1.3.1
 
 ### New Features in the Shiny App

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,15 @@
 
 # Changelog
 
+# FielDHub (development version)
+
+### Fix bugs:
+
+- Fixed a bug in `split_families()` where the `gen.list` assignment sat
+  after `stop()` inside the column-count check, so valid three-column
+  input never created `gen.list` and the function errored with "object
+  'gen.list' not found"; the assignment now runs after the guard.
+
 # FielDHub 1.3.1
 
 ### New Features in the Shiny App

--- a/R/fct_split_families.R
+++ b/R/fct_split_families.R
@@ -49,8 +49,8 @@ split_families <- function(l = NULL, data = NULL) {
   } 
   if (ncol(data) < 3) {
     stop("\n 'split_families()' requires that data have three columns: ENTRY | NAME | FAMILY.")
+  }
   gen.list <- na.omit(data[,1:3])
-  } 
   colnames(gen.list) <- c("ENTRY", "NAME", "FAMILY")
   fmlys <- factor(gen.list$FAMILY)
   familyLevels <- levels(fmlys)

--- a/tests/testthat/test_split_families.R
+++ b/tests/testthat/test_split_families.R
@@ -1,0 +1,17 @@
+library(FielDHub)
+
+test_that("split_families() assigns entries for valid three-column data", {
+  # Regression test: the na.omit() assignment to gen.list was placed after
+  # stop() inside the `if (ncol(data) < 3)` block, so for valid three-column
+  # input gen.list was never created and the function failed at
+  # colnames(gen.list) with "object 'gen.list' not found". The assignment now
+  # runs after the column-count guard.
+  gen.list <- data.frame(
+    ENTRY = 1:12,
+    NAME = paste0("SB-", 1:12),
+    FAMILY = rep(1:3, each = 4)
+  )
+  out <- split_families(l = 2, data = gen.list)
+  expect_s3_class(out, "FielDHub")
+  expect_equal(nrow(out$data_locations), 12)
+})


### PR DESCRIPTION
This PR is part of an AI-assisted bug hunt across the package source; see #62
for the overview.

## Problem
In `split_families()` the `gen.list <- na.omit(data[, 1:3])` assignment sits *inside*
the `if (ncol(data) < 3) { stop(...) }` block, after the `stop()`. For valid
three-column input the block is skipped, `gen.list` is never created, and the next
line (`colnames(gen.list) <- ...`) fails.

## Before (master, v1.5.0)
```r
gen <- data.frame(ENTRY = 1:12, NAME = paste0("SB-", 1:12), FAMILY = rep(1:3, each = 4))
FielDHub::split_families(l = 2, data = gen)
#> Error: object 'gen.list' not found
```

## After (this PR)
```r
gen <- data.frame(ENTRY = 1:12, NAME = paste0("SB-", 1:12), FAMILY = rep(1:3, each = 4))
sf <- FielDHub::split_families(l = 2, data = gen)
str(sf, max.level = 1)
#> List of 3
#>  $ rowsEachlist  :'data.frame':	2 obs. of  2 variables:
#>  $ data_locations:'data.frame':	12 obs. of  4 variables:
#>  $ infoDesign    :List of 1
#>  - attr(*, "class")= chr "FielDHub"
```

## Fix
Close the guard before the assignment so `gen.list` is built for valid input. Adds a
regression test.

Related to #62

> The before/after output above was captured locally (before on master v1.5.0, after on this branch).
