### PR TITLE
fix: assign every whole-plot to each rep in CRD split_split_plot()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -16,6 +16,12 @@ knitr::opts_chunk$set(
 
 # Changelog
 
+# FielDHub (development version)
+
+### Fix bugs:
+
+* Fixed a bug in `split_split_plot()` where, for the CRD type (`type = 1`), the whole-plot column was built with `rep(WholePlots, each = reps)` instead of `times = reps`, so whole-plots were mis-assigned across replicates; each replicate now contains every whole-plot.
+
 # FielDHub 1.3.1
 
 ### New Features in the Shiny App

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,16 @@
 
 # Changelog
 
+# FielDHub (development version)
+
+### Fix bugs:
+
+- Fixed a bug in `split_split_plot()` where, for the CRD type
+  (`type = 1`), the whole-plot column was built with
+  `rep(WholePlots, each = reps)` instead of `times = reps`, so
+  whole-plots were mis-assigned across replicates; each replicate now
+  contains every whole-plot.
+
 # FielDHub 1.3.1
 
 ### New Features in the Shiny App

--- a/R/fct_split_split_plot.R
+++ b/R/fct_split_split_plot.R
@@ -177,7 +177,7 @@ split_split_plot <- function(wp = NULL, sp = NULL, ssp = NULL, reps = NULL, type
       sspd.layout <- matrix(data = 0, nrow = wp * b, ncol = 5)
       sspd.layout[,1] <- plot.random[,v]
       sspd.layout[,2] <- rep(1:b, each = wp)
-      sspd.layout[,3] <- rep(WholePlots, each = b)
+      sspd.layout[,3] <- rep(WholePlots, times = b)
       sspd.layout <- sspd.layout[order(sspd.layout[,1]),]
       rownames(sspd.layout) <- 1:(wp * b)
       colnames(sspd.layout) <- c("PLOT", "REP", "Whole-plot", "Sub-plot", "Sub-Sub Plot")

--- a/tests/testthat/test_split_split_plot.R
+++ b/tests/testthat/test_split_split_plot.R
@@ -1,0 +1,14 @@
+library(FielDHub)
+
+test_that("split_split_plot() assigns every whole-plot to each rep under CRD (type = 1)", {
+  # Regression test for a silent bug: in the CRD branch the whole-plot column was
+  # built with rep(WholePlots, each = reps) instead of times = reps, so the
+  # whole-plots were mis-assigned across replicates (a rep could contain one
+  # whole-plot twice and miss another) rather than each rep containing every
+  # whole-plot exactly once. The test is structural because the bug is silent
+  # (no error is raised).
+  sspd <- split_split_plot(wp = 3, sp = 2, ssp = 2, reps = 2, type = 1, l = 1, seed = 1)
+  tab <- table(sspd$fieldBook$REP, sspd$fieldBook$WHOLE_PLOT)
+  # Every rep must contain every whole-plot at least once.
+  expect_true(all(tab > 0))
+})


### PR DESCRIPTION
This PR is part of an AI-assisted bug hunt across the package source; see #62
for the overview.

## Problem
For the CRD type (`type = 1`), `split_split_plot()` builds the whole-plot column with
`rep(WholePlots, each = reps)`, while the REP column is `rep(1:reps, each = wp)`. With
`each`, whole-plot labels are mis-aligned to replicates instead of each replicate
containing every whole-plot. The design is built without error, so the mistake is
silent.

## Before (master, v1.5.0)
```r
sspd <- FielDHub::split_split_plot(wp = 3, sp = 2, ssp = 2, reps = 2, type = 1, l = 1, seed = 1)
table(sspd$fieldBook$REP, sspd$fieldBook$WHOLE_PLOT)
#>
#>     1 2 3
#>   1 8 4 0
#>   2 0 4 8
```
Rep 1 is missing whole-plot 3 entirely and contains whole-plot 1 twice; rep 2 is
missing whole-plot 1.

## After (this PR)
```r
sspd <- FielDHub::split_split_plot(wp = 3, sp = 2, ssp = 2, reps = 2, type = 1, l = 1, seed = 1)
table(sspd$fieldBook$REP, sspd$fieldBook$WHOLE_PLOT)
#>
#>     1 2 3
#>   1 4 4 4
#>   2 4 4 4
```

## Fix
Use `rep(WholePlots, times = reps)` so each replicate contains every whole-plot. Adds
a regression test.

Related to #62

> The before/after output above was captured locally (before on master v1.5.0, after on this branch).
