### PR TITLE
fix: handle one-plot and single-character treatment inputs in CRD() and RCBD()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -16,6 +16,14 @@ knitr::opts_chunk$set(
 
 # Changelog
 
+# FielDHub (development version)
+
+### Fix bugs:
+
+* Fixed a bug in `CRD()` where a single experimental unit (`t = 1`, `reps = 1`) made the plot numbering `sample(plotNumber:(plotNumber + N - 1))` collapse to a full permutation and error when building the field book; it now builds the plot numbers with `plotNumber - 1 + sample(seq_len(N))`.
+
+* Fixed a bug in `CRD()` and `RCBD()` where a single character treatment matched no input branch (the third `else if` duplicated the second), leaving the treatment count `nt` unset and the call failing with "object 'nt' not found"; the branch now triggers the "requires more than one treatment" validation message.
+
 # FielDHub 1.3.1
 
 ### New Features in the Shiny App

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,22 @@
 
 # Changelog
 
+# FielDHub (development version)
+
+### Fix bugs:
+
+- Fixed a bug in `CRD()` where a single experimental unit (`t = 1`,
+  `reps = 1`) made the plot numbering
+  `sample(plotNumber:(plotNumber + N - 1))` collapse to a full
+  permutation and error when building the field book; it now builds the
+  plot numbers with `plotNumber - 1 + sample(seq_len(N))`.
+
+- Fixed a bug in `CRD()` and `RCBD()` where a single character treatment
+  matched no input branch (the third `else if` duplicated the second),
+  leaving the treatment count `nt` unset and the call failing with
+  "object 'nt' not found"; the branch now triggers the "requires more
+  than one treatment" validation message.
+
 # FielDHub 1.3.1
 
 ### New Features in the Shiny App

--- a/R/fct_CRD.R
+++ b/R/fct_CRD.R
@@ -94,7 +94,7 @@ CRD <- function(t = NULL, reps = NULL, plotNumber = 101, locationName = NULL,
       } else if (is.character(t) & length(t) > 1) {
         TRT <- t
         nt <- length(t)
-      } else if (is.character(t) & length(t) > 1) {
+      } else if (is.character(t) & length(t) == 1) {
         shiny::validate('"CRD()" requires more than one treatment.')
       }
     } else {
@@ -124,7 +124,7 @@ CRD <- function(t = NULL, reps = NULL, plotNumber = 101, locationName = NULL,
   }
 
   design <- data.frame(list(LOCATION = rep(locationName, N)),
-    PLOT = sample(plotNumber:(plotNumber + N - 1)),
+    PLOT = plotNumber - 1 + sample(seq_len(N)),
     REP = as.factor(REP), TREATMENT = TRT
   )
   design <- design[order(design$PLOT), ]

--- a/R/fct_RCBD.R
+++ b/R/fct_RCBD.R
@@ -111,7 +111,7 @@ RCBD <- function(t = NULL, reps = NULL, l = 1, plotNumber = 101,
         nt <- length(t)
         s <- t
         mytreatments <- t
-      }else if(is.character(t) & length(t) > 1) {
+      }else if(is.character(t) & length(t) == 1) {
         shiny::validate("'RCBD()' requires more than one treatment.")
       }
     }else {

--- a/tests/testthat/test_CRD.R
+++ b/tests/testthat/test_CRD.R
@@ -1,0 +1,19 @@
+library(FielDHub)
+
+test_that("CRD() works with a single experimental unit (N == 1)", {
+  # Regression test (C3): PLOT = sample(plotNumber:(plotNumber + N - 1))
+  # collapsed to sample(101:101) = sample(101) when N == 1, producing a
+  # length-101 permutation instead of a single plot number and erroring when
+  # building the field book. The fix uses plotNumber - 1 + sample(seq_len(N)).
+  crd <- CRD(t = 1, reps = 1, seed = 1)
+  expect_s3_class(crd, "FielDHub")
+  expect_equal(nrow(crd$fieldBook), 1)
+})
+
+test_that("CRD() gives an informative error for a single character treatment", {
+  # Regression test (C4): a single character treatment (e.g. t = "Wheat")
+  # matched no branch in the t-handling (the third `else if` duplicated the
+  # second), so nt was never set and CRD() failed with "object 'nt' not found".
+  # The third branch now tests length(t) == 1 and raises the intended message.
+  expect_error(CRD(t = "Wheat", reps = 3), "more than one treatment")
+})

--- a/tests/testthat/test_RCBD.R
+++ b/tests/testthat/test_RCBD.R
@@ -1,0 +1,9 @@
+library(FielDHub)
+
+test_that("RCBD() gives an informative error for a single character treatment", {
+  # Regression test (C4): a single character treatment (e.g. t = "Wheat")
+  # matched no branch in the t-handling (the third `else if` duplicated the
+  # second), so nt was never set and RCBD() failed with "object 'nt' not found".
+  # The third branch now tests length(t) == 1 and raises the intended message.
+  expect_error(RCBD(t = "Wheat", reps = 3), "more than one treatment")
+})


### PR DESCRIPTION
This PR is part of an AI-assisted bug hunt across the package source; see #62
for the overview.

## Problem
Two edge cases:
1. A single character treatment hits a dead third `else if` (it duplicates the second
   `else if` condition), so the treatment count `nt` is never set and the call errors
   with "object 'nt' not found".
2. With a single experimental unit (`t = 1, reps = 1`), the plot numbering
   `sample(plotNumber:(plotNumber + N - 1))` collapses to `sample(<one value>)`, which
   R interprets as `sample(1:value)`, breaking the field book.

## Before (master, v1.5.0)
```r
FielDHub::CRD(t = "Wheat", reps = 3)
#> Error: object 'nt' not found
FielDHub::RCBD(t = "Wheat", reps = 3)
#> Error: object 'nt' not found
FielDHub::CRD(t = 1, reps = 1)
#> Error: invalid 'row.names' length
```

## After (this PR)
```r
FielDHub::CRD(t = "Wheat", reps = 3)
#> Error: "CRD()" requires more than one treatment.
FielDHub::RCBD(t = "Wheat", reps = 3)
#> Error: 'RCBD()' requires more than one treatment.
crd1 <- FielDHub::CRD(t = 1, reps = 1)
crd1$fieldBook
#>   ID LOCATION PLOT REP TREATMENT
#> 1  1        1  101   1        T1
```

## Fix
Correct the third `else if` to test `length(t) == 1` (triggering the existing
"requires more than one treatment" validation), and build plot numbers with
`plotNumber - 1 + sample(seq_len(N))`. Adds regression tests for CRD and RCBD.
(A numeric treatment *vector* remains a separate, pre-existing gap and is
intentionally not claimed here.)

Related to #62

> The before/after output above was captured locally (before on master v1.5.0, after on this branch).
