### PR TITLE
fix: require k to equal sqrt(t) in square_lattice()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -16,6 +16,12 @@ knitr::opts_chunk$set(
 
 # Changelog
 
+# FielDHub (development version)
+
+### Fix bugs:
+
+* Fixed a bug in `square_lattice()` where only `t` was required to be a square number but `k` was not checked against `sqrt(t)`, so calls such as `square_lattice(t = 64, k = 4)` silently produced a malformed design; it now validates that `k` equals `sqrt(t)`.
+
 # FielDHub 1.3.1
 
 ### New Features in the Shiny App

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,15 @@
 
 # Changelog
 
+# FielDHub (development version)
+
+### Fix bugs:
+
+- Fixed a bug in `square_lattice()` where only `t` was required to be a
+  square number but `k` was not checked against `sqrt(t)`, so calls such
+  as `square_lattice(t = 64, k = 4)` silently produced a malformed
+  design; it now validates that `k` equals `sqrt(t)`.
+
 # FielDHub 1.3.1
 
 ### New Features in the Shiny App

--- a/R/fct_square_lattice.R
+++ b/R/fct_square_lattice.R
@@ -107,6 +107,7 @@ square_lattice <- function(t = NULL, k = NULL, r = NULL, l = 1, plotNumber = 101
     data_square <- data_up
   }
   if (sqrt(nt) %% 1 != 0) shiny::validate('square_lattice() requires t to be a square number.')
+  if (k != sqrt(nt)) shiny::validate('square_lattice() requires k to equal sqrt(t). Use rectangular_lattice() or alpha_lattice() otherwise.')
   if (!is.null(locationNames)) locationNames <- toupper(locationNames)
   if(is.null(locationNames) || length(locationNames) != l) locationNames <- 1:l
   s <- k

--- a/tests/testthat/test_square_lattice.R
+++ b/tests/testthat/test_square_lattice.R
@@ -1,0 +1,14 @@
+library(FielDHub)
+
+test_that("square_lattice() rejects k that is not sqrt(t)", {
+  # Regression test (B3): square_lattice() only checked that t is a square
+  # number, not that k == sqrt(t). With t = 64, k = 4 the call silently produced
+  # a malformed design (128 rows, wrong lambda) instead of requiring
+  # k = sqrt(64) = 8. The guard now rejects k != sqrt(t).
+  expect_error(square_lattice(t = 64, k = 4, r = 2, seed = 1), "k to equal")
+})
+
+test_that("square_lattice() still accepts k = sqrt(t)", {
+  sq <- square_lattice(t = 64, k = 8, r = 2, seed = 1)
+  expect_s3_class(sq, "FielDHub")
+})


### PR DESCRIPTION
This PR is part of an AI-assisted bug hunt across the package source; see #62
for the overview.

## Problem
`square_lattice()` checks that `t` is a perfect square but never checks that the block
size `k` equals `sqrt(t)`. A mismatched `k` is accepted silently and produces a
malformed design.

## Before (master, v1.5.0)
```r
sq <- FielDHub::square_lattice(t = 64, k = 4, r = 2, seed = 1)
dim(sq$fieldBook)            # no error, but k = 4 != sqrt(64) = 8 -> malformed design
#> [1] 128   8
```

## After (this PR)
```r
FielDHub::square_lattice(t = 64, k = 4, r = 2, seed = 1)
#> Error: square_lattice() requires k to equal sqrt(t). Use rectangular_lattice() or alpha_lattice() otherwise.
```

## Fix
Add a validation that `k == sqrt(t)`, directing users to `rectangular_lattice()` or
`alpha_lattice()` otherwise. Adds regression tests (rejects k = 4, still accepts
k = 8).

Related to #62

> The before/after output above was captured locally (before on master v1.5.0, after on this branch).
