### PR TITLE
fix: initialize best_efficiencies before the optimization loop in improve_efficiency()

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -16,6 +16,12 @@ knitr::opts_chunk$set(
 
 # Changelog
 
+# FielDHub (development version)
+
+### Fix bugs:
+
+* Fixed a bug in `row_column()` where the design optimizer errored with "object 'best_efficiencies' not found" when no treatment swap improved the A-efficiency, because the best efficiencies were only stored inside the improvement branch; they are now initialized from the starting design.
+
 # FielDHub 1.3.1
 
 ### New Features in the Shiny App

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,16 @@
 
 # Changelog
 
+# FielDHub (development version)
+
+### Fix bugs:
+
+- Fixed a bug in `row_column()` where the design optimizer errored with
+  "object 'best_efficiencies' not found" when no treatment swap improved
+  the A-efficiency, because the best efficiencies were only stored inside
+  the improvement branch; they are now initialized from the starting
+  design.
+
 # FielDHub 1.3.1
 
 ### New Features in the Shiny App

--- a/R/utils_row_col_optimization.R
+++ b/R/utils_row_col_optimization.R
@@ -47,6 +47,7 @@ improve_efficiency <- function(design, iterations, seed) {
     dplyr::select(Level_1, Level_3, plots, treatments)
   efficiencies <- BlockEfficiencies(row_blocks)
   best_a_efficiency <- efficiencies$`A-Efficiency`[efficiencies$Level == 2]
+  best_efficiencies <- efficiencies
   
   # Run iterations to improve A-Efficiency
   for (i in 1:iterations) {

--- a/tests/testthat/test_improve_efficiency.R
+++ b/tests/testthat/test_improve_efficiency.R
@@ -1,0 +1,29 @@
+library(FielDHub)
+
+test_that("improve_efficiency() returns efficiencies when no swap improves the design", {
+  # Regression test (CAL): improve_efficiency() only assigned best_efficiencies
+  # inside the "new A-efficiency is higher" branch, so when no treatment swap
+  # improved the design it referenced an undefined object at return() and errored
+  # with "object 'best_efficiencies' not found".
+  # This minimal design forces the no-improvement path two independent ways: with
+  # one plot per (Level_1, Level_2) cell swap_treatments() cannot swap anything,
+  # and the complete row blocks are already A-optimal (A-efficiency 1).
+  nt <- 4L
+  reps <- 2L
+  design <- data.frame(
+    Level_1    = factor(rep(seq_len(reps), each = nt)),
+    Level_2    = factor(rep(seq_len(nt), times = reps)),
+    Level_3    = factor(rep(paste0(seq_len(reps), ".B1"), each = nt)),
+    plots      = seq_len(nt * reps),
+    treatments = factor(rep(seq_len(nt), times = reps))
+  )
+
+  res <- improve_efficiency(design, iterations = 5, seed = 1)
+
+  expect_type(res, "list")
+  expect_named(res, c("best_design", "best_efficiencies", "best_a_efficiency"))
+  expect_s3_class(res$best_efficiencies, "data.frame")
+  expect_true("A-Efficiency" %in% names(res$best_efficiencies))
+  # No swap improved the design, so the best design is the starting design.
+  expect_equal(nrow(res$best_design), nrow(design))
+})


### PR DESCRIPTION
This PR is part of an AI-assisted bug hunt across the package source; see #62
for the overview.

## Problem
In `improve_efficiency()` (used by `row_column()`), `best_efficiencies` is only
assigned inside the branch that runs when a swap improves the A-efficiency. If no swap
improves it, the variable is never created and the function errors when it returns its
result.

## Before (master, v1.5.0)
```r
# a minimal design where no treatment swap can improve the A-efficiency
nt <- 4L
reps <- 2L
design <- data.frame(
  Level_1    = factor(rep(seq_len(reps), each = nt)),
  Level_2    = factor(rep(seq_len(nt), times = reps)),
  Level_3    = factor(rep(paste0(seq_len(reps), ".B1"), each = nt)),
  plots      = seq_len(nt * reps),
  treatments = factor(rep(seq_len(nt), times = reps))
)
FielDHub:::improve_efficiency(design, iterations = 5, seed = 1)
#> Error: object 'best_efficiencies' not found
```

## After (this PR)
```r
# a minimal design where no treatment swap can improve the A-efficiency
nt <- 4L
reps <- 2L
design <- data.frame(
  Level_1    = factor(rep(seq_len(reps), each = nt)),
  Level_2    = factor(rep(seq_len(nt), times = reps)),
  Level_3    = factor(rep(paste0(seq_len(reps), ".B1"), each = nt)),
  plots      = seq_len(nt * reps),
  treatments = factor(rep(seq_len(nt), times = reps))
)
res <- FielDHub:::improve_efficiency(design, iterations = 5, seed = 1)
names(res)
#> [1] "best_design"       "best_efficiencies" "best_a_efficiency"
res$best_efficiencies
#>   Level Blocks D-Efficiency A-Efficiency A-Bound
#> 1     1      2            1            1       1
#> 2     2      2            1            1       1
```

## Fix
Initialise `best_efficiencies <- efficiencies` from the starting design before the
loop. Adds a regression test using a design where no swap can improve the
A-efficiency.

Related to #62

> The before/after output above was captured locally (before on master v1.5.0, after on this branch).
