### PR TITLE
Simplify field-map label drawing: drop the ggplot overlay, apply `shorten = "no"` consistently

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -33,6 +33,7 @@ knitr::opts_chunk$set(
 * Fixed a bug in `CRD()` and `RCBD()` where a single character treatment matched no input branch (the third `else if` duplicated the second), leaving the treatment count `nt` unset and the call failing with "object 'nt' not found"; the branch now triggers the "requires more than one treatment" validation message.
 * Fixed a bug in `square_lattice()` where only `t` was required to be a square number but `k` was not checked against `sqrt(t)`, so calls such as `square_lattice(t = 64, k = 4)` silently produced a malformed design; it now validates that `k` equals `sqrt(t)`.
 * Fixed a bug in `row_column()` where the design optimizer errored with "object 'best_efficiencies' not found" when no treatment swap improved the A-efficiency, because the best efficiencies were only stored inside the improvement branch; they are now initialized from the starting design.
+* Fixed a bug in the layout plots of `diagonal_arrangement()`, `partially_replicated()` and `optimized_arrangement()` where the cell labels were passed through `desplot`'s default abbreviation (`shorten = "abb"`), so three-digit entry numbers were drawn without their leading digit (entry 108 appeared as `08`); the labels are now drawn verbatim. The augmented RCBD layout, which avoided this by drawing its labels with a `ggplot2::geom_text()` overlay on top of desplot, now uses the native `desplot` arguments as well, so its check entries are still highlighted in red but no longer in bold.
 
 # FielDHub 1.3.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -67,6 +67,15 @@
   the A-efficiency, because the best efficiencies were only stored inside
   the improvement branch; they are now initialized from the starting
   design.
+- Fixed a bug in the layout plots of `diagonal_arrangement()`,
+  `partially_replicated()` and `optimized_arrangement()` where the cell
+  labels were passed through `desplot`'s default abbreviation
+  (`shorten = "abb"`), so three-digit entry numbers were drawn without
+  their leading digit (entry 108 appeared as `08`); the labels are now
+  drawn verbatim. The augmented RCBD layout, which avoided this by
+  drawing its labels with a `ggplot2::geom_text()` overlay on top of
+  desplot, now uses the native `desplot` arguments as well, so its check
+  entries are still highlighted in red but no longer in bold.
 
 # FielDHub 1.3.1
 

--- a/R/globals.R
+++ b/R/globals.R
@@ -35,4 +35,4 @@ utils::globalVariables(c("ENTRY",
                          "plots", "arcbd_plot", "new_order_treatments", 
                          "LABEL_TREATMENT",
                          "Level", 
-                         "Level_3", "ID", "YEAR", "IS_CHECK", "PLOT_TXT"))
+                         "Level_3", "ID", "YEAR", "CHECK_TEXT", "PLOT_TXT"))

--- a/R/utils_plot_diagonal_arrangement.R
+++ b/R/utils_plot_diagonal_arrangement.R
@@ -22,6 +22,7 @@ plot_diagonal_arrangement <- function(x, l) {
         text = ENTRY, 
         col = CHECKS, 
         cex = 1, 
+        shorten = "no",
         out1 = EXPT,
         out2 = CHECKS, 
         xlab = "COLUMNS", 
@@ -64,6 +65,7 @@ plot_prep <- function(x, l) {
         ylab = "ROWS",
         main = main,
         cex = 1,
+        shorten = "no",
         show.key = FALSE, 
         gg = TRUE,
         col.regions = c("gray", "seagreen")
@@ -98,6 +100,7 @@ plot_optim <- function(x, l) {
         CHECKS ~ COLUMN + ROW,
         text= ENTRY,
         cex=1,
+        shorten = "no",
         main = main,
         show.key=FALSE,
         xlab = "COLUMNS",
@@ -127,15 +130,22 @@ plot_augmented_RCBD <- function(x, l) {
   loc_field_book$CHECKS <- as.character(loc_field_book$CHECKS)
   loc_field_book$BLOCK <- as.character(loc_field_book$BLOCK)
   
-  # labels that must NEVER be reformatted by desplot
+  # plot numbers as plain integers, whatever PLOT is stored as
   loc_field_book$PLOT_TXT <- sprintf("%d", as.integer(loc_field_book$PLOT))
   
-  # flag checks (used only for p1 text color)
-  loc_field_book$IS_CHECK <- loc_field_book$CHECKS == "1"
+  # text color groups for p1: checks are highlighted, test lines are not
+  loc_field_book$CHECK_TEXT <- ifelse(loc_field_book$CHECKS == "1",
+                                      "check", "test")
+  check_text_cols <- c(check = "red3", test = "gray10")
   
   # -----------------------------
   # Muted palette for BLOCK bg
   # -----------------------------
+  # This is added as a scale_fill_manual() layer instead of being passed to
+  # desplot as 'col.regions': in desplot 1.10 that argument is dropped for
+  # factor fills in the ggplot2 branch. Once a desplot release carrying the fix
+  # is on CRAN, both layers below can be replaced by 'col.regions = fill_vals'
+  # in the ggdesplot() calls.
   block_levels <- sort(unique(loc_field_book$BLOCK))
   muted6 <- c("#F2F2F2", "#E6EEF5", "#E9F2EC", "#F3EEE6", "#EDE7F2", "#F1E9E9")
   if (length(block_levels) > length(muted6)) {
@@ -150,11 +160,13 @@ plot_augmented_RCBD <- function(x, l) {
   # -----------------------------
   main <- paste0("Augmented RCBD Layout ", rows, " x ", cols)
   
-  p1_bg <- desplot::ggdesplot(
+  p1 <- desplot::ggdesplot(
     BLOCK ~ COLUMN + ROW,
-    text = "",
-    cex = 0,
-    col = BLOCK,   # bg by block (muted palette)
+    text = ENTRY,
+    cex = 0.8,
+    shorten = "no",
+    col = CHECK_TEXT,
+    col.text = check_text_cols,
     out1 = EXPT,
     out2 = BLOCK,
     data = loc_field_book,
@@ -164,33 +176,8 @@ plot_augmented_RCBD <- function(x, l) {
     show.key = FALSE,
     gg = TRUE,
     out2.gpar = list(col = "gray50", lwd = 1, lty = 1)
-  )
-  
-  p1 <- p1_bg +
-    ggplot2::scale_fill_manual(values = fill_vals, guide = "none") +
-    ggplot2::geom_text(
-      data = dplyr::filter(loc_field_book, !IS_CHECK),
-      ggplot2::aes(
-        x = as.numeric(COLUMN),
-        y = as.numeric(ROW),
-        label = ENTRY
-      ),
-      inherit.aes = FALSE,
-      color = "gray10",
-      size = 3.2
-    ) +
-    ggplot2::geom_text(
-      data = dplyr::filter(loc_field_book, IS_CHECK),
-      ggplot2::aes(
-        x = as.numeric(COLUMN),
-        y = as.numeric(ROW),
-        label = ENTRY
-      ),
-      inherit.aes = FALSE,
-      color = "red3",
-      fontface = "bold",
-      size = 3.2
-    )
+  ) +
+    ggplot2::scale_fill_manual(values = fill_vals, guide = "none")
   
   p1 <- add_gg_features(p1)
   
@@ -199,11 +186,12 @@ plot_augmented_RCBD <- function(x, l) {
   # -----------------------------
   main_plot <- paste0("Augmented RCBD Plot Number Layout ", rows, " x ", cols)
   
-  p2_bg <- desplot::ggdesplot(
+  p2 <- desplot::ggdesplot(
     BLOCK ~ COLUMN + ROW,
-    text = "",
-    cex = 0,
-    col = BLOCK,   # keep same muted bg by block
+    text = PLOT_TXT,
+    cex = 0.8,
+    shorten = "no",
+    col.text = "gray10",
     out1 = EXPT,
     out2 = BLOCK,
     data = loc_field_book,
@@ -213,21 +201,8 @@ plot_augmented_RCBD <- function(x, l) {
     show.key = FALSE,
     gg = TRUE,
     out2.gpar = list(col = "gray50", lwd = 1, lty = 1)
-  )
-  
-  p2 <- p2_bg +
-    ggplot2::scale_fill_manual(values = fill_vals, guide = "none") +
-    ggplot2::geom_text(
-      data = loc_field_book,
-      ggplot2::aes(
-        x = as.numeric(COLUMN),
-        y = as.numeric(ROW),
-        label = PLOT_TXT
-      ),
-      inherit.aes = FALSE,
-      color = "gray10",
-      size = 3.2
-    )
+  ) +
+    ggplot2::scale_fill_manual(values = fill_vals, guide = "none")
   
   p2 <- add_gg_features(p2)
   

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -41,6 +41,7 @@ approximatelly
 blocksdesign
 cranlogs
 de
+desplot
 doi
 dropdown
 extensibility

--- a/tests/testthat/test_plot_labels.R
+++ b/tests/testthat/test_plot_labels.R
@@ -1,0 +1,102 @@
+library(FielDHub)
+
+# Cell text on a field map must be drawn exactly as it is stored. desplot's
+# default is shorten = "abb", which runs abbreviate() over the labels and turns
+# three-digit entry numbers into two-digit ones (100 -> "00", 108 -> "08"),
+# i.e. it silently shows a different, equally plausible entry number.
+
+# All text layers that are actually visible (the layer that desplot adds when
+# only 'col' is given carries size 0 and no label of interest).
+drawn_text <- function(p) {
+  out <- list()
+  for (i in seq_along(p$layers)) {
+    if (class(p$layers[[i]]$geom)[1] != "GeomText") next
+    d <- ggplot2::layer_data(p, i)
+    if (max(as.numeric(d$size)) == 0) next
+    out[[length(out) + 1L]] <- d
+  }
+  out
+}
+
+tile_fills <- function(p) {
+  ix <- which(vapply(p$layers, function(l) class(l$geom)[1] == "GeomTile", TRUE))
+  sort(unique(as.character(ggplot2::layer_data(p, ix[1])$fill)))
+}
+
+# Guard against a vacuous test: the labels must be such that abbreviation
+# would in fact change them.
+expect_abbreviation_would_bite <- function(labels) {
+  u <- unique(as.character(labels))
+  expect_false(all(unname(abbreviate(u, 2, method = "both")) == u))
+}
+
+# One visible text layer whose labels are the expected ones, verbatim.
+expect_labels_verbatim <- function(p, expected) {
+  expected <- as.character(expected)
+  expect_abbreviation_would_bite(expected)
+  layers <- drawn_text(p)
+  expect_length(layers, 1L)
+  expect_equal(sort(as.character(layers[[1]]$label)), sort(expected))
+}
+
+test_that("diagonal arrangement draws entry numbers unabbreviated", {
+  d <- diagonal_arrangement(
+    nrows = 15, ncols = 10, lines = 120, checks = 4,
+    plotNumber = 101, seed = 1
+  )
+  p <- plot_diagonal_arrangement(d, l = 1)
+  expect_labels_verbatim(p$p1, as.numeric(d$fieldBook$ENTRY))
+})
+
+test_that("partially replicated design draws entry numbers unabbreviated", {
+  p_rep <- partially_replicated(
+    nrows = 14, ncols = 10, repGens = c(20, 100), repUnits = c(2, 1),
+    plotNumber = 101, seed = 1
+  )
+  p <- plot_prep(p_rep, l = 1)
+  expect_labels_verbatim(p$p1, p_rep$fieldBook$ENTRY)
+})
+
+test_that("optimized arrangement draws entry numbers unabbreviated", {
+  o <- optimized_arrangement(
+    nrows = 12, ncols = 10, lines = 110, amountChecks = 10, checks = 1,
+    plotNumber = 101, seed = 1
+  )
+  p <- plot_optim(o, l = 1)
+  expect_labels_verbatim(p$p1, o$fieldBook$ENTRY)
+})
+
+# The augmented RCBD layout used to draw its cell text with ggplot2::geom_text()
+# layers on top of a desplot plot whose own text was switched off. desplot draws
+# the same thing natively, and the checks keep their own text colour.
+test_that("augmented RCBD layout draws entries natively, checks in red", {
+  a <- RCBD_augmented(
+    lines = 110, checks = 4, b = 6, l = 1,
+    plotNumber = 101, seed = 1
+  )
+  fb <- a$fieldBook
+  p <- plot_augmented_RCBD(a, l = 1)
+
+  # p1: entry numbers, verbatim, in a single text layer
+  expect_labels_verbatim(p$p1, fb$ENTRY)
+  d1 <- drawn_text(p$p1)[[1]]
+
+  # the checks - and only the checks - are red
+  is_check <- as.character(fb$CHECKS) == "1"
+  expect_true(any(is_check))
+  expect_setequal(unique(as.character(d1$colour)), c("gray10", "red3"))
+  expect_equal(
+    sort(as.character(d1$label[d1$colour == "red3"])),
+    sort(as.character(fb$ENTRY[is_check]))
+  )
+
+  # text size and the muted block background are the ones the overlay produced
+  expect_equal(unique(as.numeric(d1$size)), 3.2)
+  expect_length(tile_fills(p$p1), length(unique(fb$BLOCK)))
+
+  # p2: plot numbers, verbatim, one colour, same size
+  expect_labels_verbatim(p$p2, sprintf("%d", as.integer(fb$PLOT)))
+  d2 <- drawn_text(p$p2)[[1]]
+  expect_equal(unique(as.character(d2$colour)), "gray10")
+  expect_equal(unique(as.numeric(d2$size)), 3.2)
+})

--- a/tests/testthat/test_plot_labels.R
+++ b/tests/testthat/test_plot_labels.R
@@ -48,6 +48,17 @@ test_that("diagonal arrangement draws entry numbers unabbreviated", {
   expect_labels_verbatim(p$p1, as.numeric(d$fieldBook$ENTRY))
 })
 
+test_that("plot() reaches the same labels through the public API", {
+  d <- diagonal_arrangement(
+    nrows = 15, ncols = 10, lines = 120, checks = 4,
+    plotNumber = 101, seed = 1
+  )
+  # plot() prints its layout, so send that to a null device
+  pdf(NULL)
+  on.exit(dev.off(), add = TRUE)
+  expect_labels_verbatim(plot(d)$p, as.numeric(d$fieldBook$ENTRY))
+})
+
 test_that("partially replicated design draws entry numbers unabbreviated", {
   p_rep <- partially_replicated(
     nrows = 14, ncols = 10, repGens = c(20, 100), repUnits = c(2, 1),


### PR DESCRIPTION
Two related cleanups to how the field maps draw their cell labels, both touching the
plotting points raised in #72. They share one root cause: `desplot`'s default
`shorten = "abb"`, which runs `abbreviate()` over the labels.

## 1. Drop the geom_text overlay in the augmented RCBD layout

`plot_augmented_RCBD()` did not let desplot draw its labels at all. It switched the text
off (`text = ""`, `cex = 0`) and painted the entry and plot numbers back on with
`ggplot2::geom_text()` layers, carrying the comment *"labels that must NEVER be
reformatted by desplot"*. This is exactly the overlay pattern discussed in #72.

The reason for the workaround was only `shorten = "abb"` - and desplot can already draw
the labels verbatim with `shorten = "no"`. So the panels now go through desplot natively:
`text = ENTRY` / `text = PLOT_TXT`, the two text colours via `col = CHECK_TEXT` +
`col.text`, and `cex = 0.8` so the drawn text keeps the size the overlay had (desplot
uses `4 * cex`). That removes both `geom_text()` overlays and the dead `col = BLOCK`
argument (it colours text, and the text was switched off), net -25 lines. As agreed in
#72, the checks keep their red colour but are no longer bold.

## 2. Apply `shorten = "no"` consistently on the ggplot2 path

The same default was left in place at three other call sites, so there the labels *were*
silently reformatted. FielDHub already passes `shorten = "no"` on its lattice-path calls,
but `plot_diagonal_arrangement()`, `plot_prep()` and `plot_optim()` did not, so
three-digit entry numbers were drawn without their leading digit - entry `108` as `08`.
The map looks perfectly plausible and shows a different entry number than the field book,
which is the kind of error that travels to the field. It affects `diagonal_arrangement()`,
`partially_replicated()` and `optimized_arrangement()`, both through `plot()` and in the
Shiny app.

### Reproducer

Run against v1.5.0 (desplot 1.10, ggplot2 4.0.2):

```r
library(FielDHub)

d <- diagonal_arrangement(
  nrows = 15, ncols = 10, lines = 120, checks = 4,
  plotNumber = 101, seed = 1
)
p <- plot(d)$p

# the cell-text layer of the field map
i <- which(vapply(p$layers, function(l) inherits(l$geom, "GeomText"), TRUE))
drawn <- ggplot2::layer_data(p, i)$label

sort(setdiff(as.character(drawn), as.character(d$fieldBook$ENTRY)))
#>  [1] "00" "01" "02" "03" "04" "05" "06" "07" "08" "09"
```

Ten labels are drawn that are not entry numbers of this design at all: entries 100-109
appear as `00`-`09`. With this branch the same code returns `character(0)`.

## Note on the block background

The muted block background stays a `scale_fill_manual()` layer rather than moving to
`col.regions`: in desplot 1.10 that argument is dropped for factor fills in the ggplot2
branch. A comment marks the spot so it can be simplified once a desplot release with the
fix is on CRAN.

## Verification

- New `tests/testthat/test_plot_labels.R` (25 expectations): 8 fail on the parent
  commit, all pass on this branch. It pins the labels of all four layouts - both
  through the internal plot helpers and through `plot()` itself - plus the
  check/test-line text colours, the text size and the block palette, and it guards
  against becoming vacuous by asserting that abbreviation would in fact change the
  labels.
- Full test suite in `R CMD check --as-cran`: `FAIL 0 | WARN 0 | SKIP 0 | PASS 238`.
- No new check findings versus the parent commit: an `--as-cran` run of this branch
  and of `upstream/master` both end in the same one WARNING (`--as-cran` version
  check, since a bugfix PR does not bump the package version) and the same one NOTE
  (the pre-existing `spelling.Rout` difference for `errored`, `mis` and `nt`, all from
  earlier NEWS entries). The branch only adds 25 passing tests (238 vs 213).

Related to #72.

*Prepared with the help of an AI coding assistant; the reproducer above was run and
verified locally.*
